### PR TITLE
Add currently known information

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,11 +97,27 @@
           <li class="list-group-item gray">
             Fate Reforged
           </li>
-          <li class="list-group-item gray">
-            ...
-          </li>
           <span class="label label-default">
             Fate Reforged releases January 23, 2015
+          </span>
+          <br />
+          <span class="label label-success">
+            Until early/mid 2016
+          </span>
+        </ul>
+        <ul class="list-group">
+          <li class="list-group-item gray">
+            Dragons of Tarkir
+          </li>
+          <li class="list-group-item gray">
+            2016 Core Set
+          </li>
+          <span class="label label-default">
+            Dragons of Tarkir releases March 27, 2015
+          </span>
+          <br />
+          <span class="label label-success">
+            Until late 2016
           </span>
         </ul>
       </div>


### PR DESCRIPTION
This contains 3 commits:
1) A quick README tweak to reflect the presence of SVG images.
2) Added DTK, including its release date, added Magic 2016, and exit ("Until") information for KTK, FRF, DTK, and 2016. Also switched exit labels to use Spring/Fall to match Wizards' usage.
3) Bumped API to version 4 and changed API `rough_exit_date` to use Spring/Fall to match Wizards' usage.

Thanks for making this, it's really useful! :ok_hand: 
