### PR TITLE
Correct JPG -> SVG links in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This is the only API call we have. It returns a JSON array of sets which looks s
     "name": "Theros",
     "block": "Theros",
     "code": "THS",
-    "symbol": "http://whatsinstandard.com/img/ths.jpg",
+    "symbol": "http://whatsinstandard.com/img/ths.svg",
     "enter_date": "2013-09-27T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"

--- a/api/1/sets.json
+++ b/api/1/sets.json
@@ -3,7 +3,7 @@
     "name": "Theros",
     "block": "Theros",
     "code": "THS",
-    "symbol": "http://whatsinstandard.com/img/ths.jpg",
+    "symbol": "http://whatsinstandard.com/img/ths.svg",
     "enter_date": "2013-09-27T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"

--- a/api/2/sets.json
+++ b/api/2/sets.json
@@ -3,7 +3,7 @@
     "name": "Theros",
     "block": "Theros",
     "code": "THS",
-    "symbol": "http://whatsinstandard.com/img/ths.jpg",
+    "symbol": "http://whatsinstandard.com/img/ths.svg",
     "enter_date": "2013-09-27T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -12,7 +12,7 @@
     "name": "Born of the Gods",
     "block": "Theros",
     "code": "BNG",
-    "symbol": "http://whatsinstandard.com/img/bng.jpg",
+    "symbol": "http://whatsinstandard.com/img/bng.svg",
     "enter_date": "2014-02-07T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -21,7 +21,7 @@
     "name": "Journey into Nyx",
     "block": "Theros",
     "code": "JOU",
-    "symbol": "http://whatsinstandard.com/img/jou.jpg",
+    "symbol": "http://whatsinstandard.com/img/jou.svg",
     "enter_date": "2014-05-02T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -30,7 +30,7 @@
     "name": "2015 Core Set",
     "block": null,
     "code": "M15",
-    "symbol": "http://whatsinstandard.com/img/m15.jpg",
+    "symbol": "http://whatsinstandard.com/img/m15.svg",
     "enter_date": "2014-07-18T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -39,7 +39,7 @@
     "name": "Khans of Tarkir",
     "block": "Khans of Tarkir",
     "code": "KTK",
-    "symbol": "http://whatsinstandard.com/img/ktk.jpg",
+    "symbol": "http://whatsinstandard.com/img/ktk.svg",
     "enter_date": "2014-09-26T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "early 2016"

--- a/api/3/sets.json
+++ b/api/3/sets.json
@@ -3,7 +3,7 @@
     "name": "Theros",
     "block": "Theros",
     "code": "THS",
-    "symbol": "http://whatsinstandard.com/img/ths.jpg",
+    "symbol": "http://whatsinstandard.com/img/ths.svg",
     "enter_date": "2013-09-27T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -12,7 +12,7 @@
     "name": "Born of the Gods",
     "block": "Theros",
     "code": "BNG",
-    "symbol": "http://whatsinstandard.com/img/bng.jpg",
+    "symbol": "http://whatsinstandard.com/img/bng.svg",
     "enter_date": "2014-02-07T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -21,7 +21,7 @@
     "name": "Journey into Nyx",
     "block": "Theros",
     "code": "JOU",
-    "symbol": "http://whatsinstandard.com/img/jou.jpg",
+    "symbol": "http://whatsinstandard.com/img/jou.svg",
     "enter_date": "2014-05-02T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -30,7 +30,7 @@
     "name": "2015 Core Set",
     "block": null,
     "code": "M15",
-    "symbol": "http://whatsinstandard.com/img/m15.jpg",
+    "symbol": "http://whatsinstandard.com/img/m15.svg",
     "enter_date": "2014-07-18T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "late 2015"
@@ -39,7 +39,7 @@
     "name": "Khans of Tarkir",
     "block": "Khans of Tarkir",
     "code": "KTK",
-    "symbol": "http://whatsinstandard.com/img/ktk.jpg",
+    "symbol": "http://whatsinstandard.com/img/ktk.svg",
     "enter_date": "2014-09-26T00:00:00.000Z",
     "exit_date": null,
     "rough_exit_date": "early/mid 2016"


### PR DESCRIPTION
Looks like when the logos were converted from JPG to SVG, the API JSONs weren't updated, so this takes care of that.