### PR TITLE
Updated README to show non-archived webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Thanks to:
 * For gathering them: [jninnes][7]
 
 [0]: http://whatsinstandard.com/
-[1]: http://www.wizards.com/magic/magazine/article.aspx?x=judge/resources/sfrstandard
+[1]: http://magic.wizards.com/en/content/standard-formats-magic-gathering 
 [2]: http://mtgimage.com/
 [3]: http://gatherer.wizards.com/Handlers/Image.ashx?type=symbol&set=RTR&size=large&rarity=C
 [4]: https://github.com/bower/bower


### PR DESCRIPTION
http://www.wizards.com/magic/magazine/article.aspx?x=judge/resources/sfrstandard redirects to an archived page. I have updated the link to a current page regarding the Standard format.