### PR TITLE
Rotated out list

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Thanks to:
 * For gathering them: [jninnes][7]
 
 [0]: http://whatsinstandard.com/
-[1]: http://www.wizards.com/magic/magazine/article.aspx?x=judge/resources/sfrstandard
+[1]: http://magic.wizards.com/en/content/standard-formats-magic-gathering 
 [2]: http://mtgimage.com/
 [3]: http://gatherer.wizards.com/Handlers/Image.ashx?type=symbol&set=RTR&size=large&rarity=C
 [4]: https://github.com/bower/bower

--- a/img/bng.svg
+++ b/img/bng.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="600"
+   height="548.17926"
+   id="svg3776"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="drawing.svg">
+  <defs
+     id="defs3778" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="281.36086"
+     inkscape:cy="243.6757"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1440"
+     inkscape:window-height="881"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3781">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(613.3437,-45.544512)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m -221.44756,45.544655 -7.8569,10.821766 -14.17207,19.508828 c -11.62251,15.968674 -29.01891,50.807911 -38.57292,92.533511 l -0.0593,0.23719 c -9.51037,41.69657 -10.82768,90.6507 16.06958,129.56471 18.05803,26.12572 18.51861,50.92475 9.0725,70.00053 -9.42022,19.02347 -29.13314,32.70983 -56.48073,33.82913 -0.0507,0.002 -0.0976,-0.002 -0.14824,0 l -0.0296,0 -0.41509,0.0296 -0.35578,0 -0.38543,-0.0296 -0.0593,0 c -0.0507,-0.002 -0.0976,0.002 -0.14824,0 -27.3475,-1.11928 -47.0294,-14.80272 -56.45108,-33.82913 -9.44612,-19.07578 -8.98553,-43.87482 9.07249,-70.00053 26.94862,-38.98832 25.53922,-88.05633 15.98064,-129.8019 -9.55357,-41.72369 -26.91861,-76.561876 -38.54328,-92.533511 l -14.17206,-19.508828 -7.8569,-10.792118 -0.71157,13.341904 -1.30454,24.074724 c -2.58297,48.273759 -3.55438,92.421689 -29.53008,131.877309 -17.20116,-20.34899 -36.59535,-33.2671 -56.83651,-40.73728 -24.71106,-9.11984 -50.14191,-10.54733 -74.83326,-10.70317 l -27.75116,-0.20754 -15.41731,-0.0889 12.65998,8.74636 22.85913,15.77309 c 21.26957,14.68437 48.8945,35.48781 62.46976,70.05982 13.58512,34.59717 14.3666,84.46144 -24.19332,161.02195 -0.004,0.009 0.004,0.0215 0,0.0296 l -1.39349,2.69803 -0.80051,1.54173 0.41508,1.68997 0.68192,2.99452 c 0.002,0.009 -0.002,0.0202 0,0.0296 12.21867,53.62065 44.81321,95.69172 86.81132,123.87216 l 0,0.0889 2.04576,1.42314 c 0.28783,0.1974 0.0166,-0.0156 0.0889,0.0296 0.0814,0.0509 0.28394,0.19488 0.0889,0.0593 -0.0506,-0.0352 0.0989,0.0474 0.0296,0 40.75397,27.89264 89.14286,40.82418 137.09547,40.52974 -0.0406,2.8e-4 0.27808,7.4e-4 0.56333,0 0.015,-4e-5 0.0148,4e-5 0.0296,0 0.0698,1.7e-4 0.11898,0 0.11859,0 47.97779,0.26465 96.37434,-12.66101 137.12513,-40.61869 -0.0809,0.0555 -0.0453,0.0329 0.0889,-0.0593 42.99794,-28.18085 76.38557,-70.84882 88.797786,-125.35459 l 0,-0.0296 0.681919,-3.02416 0.355784,-1.63068 -0.741217,-1.51208 -1.363839,-2.72768 c -38.555643,-76.54096 -37.372663,-126.31686 -23.392803,-160.93301 13.96723,-34.58492 42.024401,-55.449 63.359217,-70.17841 l 22.82948,-15.7731 12.689633,-8.74636 -15.417311,0.0889 -27.75116,0.20754 -0.02965,0 c -24.68383,0.15681 -50.512129,1.58599 -75.604119,10.67353 -20.58311,7.45456 -40.37706,20.36772 -57.75562,40.79657 -25.99428,-39.46287 -26.94688,-83.629 -29.53008,-131.906951 l -1.30454,-24.074724 -0.71157,-13.371553 z"
+       id="path3002"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccssccccccccsssccccccscccccscccccccccccccccccccccccccsccccccsccccc" />
+    <path
+       style="fill:#000000;stroke:none"
+       d="m -395.6891,83.701663 c -2.86373,53.520937 -3.53225,106.604947 -42.62161,153.248987 -36.81523,-54.23626 -83.52495,-59.93118 -131.93819,-60.23676 43.28213,29.88171 121.90745,90.50858 42.56767,248.01466 11.63353,51.08636 42.76937,90.84735 83.43586,117.39827 38.31534,26.28697 84.08386,38.55847 129.67222,38.27854 0.24361,-0.002 0.48474,0.003 0.72834,0 45.64898,0.2803 91.48771,-12.02722 129.8341,-38.38644 40.58687,-26.5507 71.65599,-66.27213 83.274,-117.29037 -79.33977,-157.50607 1.011992,-218.13294 44.294114,-248.01465 -48.413234,0.30558 -96.822434,6.0005 -133.637654,60.23676 -39.08936,-46.64405 -39.78487,-99.72806 -42.6486,-153.248997 -19.48348,26.769187 -69.97993,138.039927 -22.36286,206.930637 40.65507,58.81832 5.47435,122.22258 -57.9708,124.70869 l -1.15995,0.054 -1.13299,-0.054 c -63.44513,-2.48611 -98.62584,-65.89036 -57.97078,-124.70869 47.61707,-68.89071 -2.87939,-180.16145 -22.36287,-206.930637 z"
+       id="path2989"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/img/ths.svg
+++ b/img/ths.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="600"
+   height="602.66986"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="Theros Common.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.5"
+     inkscape:cx="388.48386"
+     inkscape:cy="292.39945"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1025"
+     inkscape:window-height="767"
+     inkscape:window-x="279"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2995"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="174.46645px"
+       originy="-95.1875px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(230.33321,-140.92386)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:43.59999847000000300;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m -56.111695,140.92386 0,21.63462 0,25.78798 0,6.78794 3.874395,5.54813 59.6036926,85.67062 0,235.43924 -38.8989256,0 C -105.397,476.47444 -106.39383,364.92695 -37.979526,317.16234 l 17.54326,-12.24309 -12.026122,-17.63624 -48.60041,-71.41285 -12.49105,-18.34914 -18.008192,12.95598 c -68.60566,49.34523 -114.24635,120.94125 -118.4635,198.36902 -3.94328,72.39937 29.89498,147.93018 108.63804,209.18634 l -61.02947,91.96264 -22.28552,33.59875 40.2937,0 468.1509,0 40.29371,0 L 321.7503,709.995 260.72083,618.03236 C 339.44711,556.81931 373.30496,481.504 369.35886,409.31095 365.13867,332.10337 319.47125,260.79267 250.89536,211.46885 l -17.88421,-12.89399 -12.52204,18.16316 -48.60041,70.42101 -12.21209,17.69823 17.63624,12.30508 c 68.4143,47.76461 67.41747,159.3121 -6.44699,204.63005 l -38.89893,0 0,-235.43924 59.60369,-85.67062 3.8744,-5.54813 0,-6.78794 0,-25.78798 0,-21.63462 -21.63462,0 -208.287473,0 z"
+       id="path3773"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccsccccccccsccccccccccccccccc" />
+    <path
+       style="fill:#000000;stroke:none"
+       d="m -34.477073,162.55848 0,25.78798 63.478087,91.24975 0,263.8308 -66.453623,0 C -129.7531,492.29582 -133.31557,357.35931 -50.346595,299.43311 l -48.600411,-71.41285 c -128.484744,92.4138 -165.766764,264.61015 6.942916,384.83591 l -72.40469,109.10296 c 415.8778,0 109.188758,0 468.15089,0 L 231.33742,612.85617 C 404.04711,492.63041 366.76508,321.42591 238.28033,229.01211 l -48.60041,70.421 c 82.96898,57.9262 79.40651,192.86271 -12.89398,243.9939 l -66.45363,0 0,-263.8308 63.47809,-91.24975 0,-25.78798 c -169.2885885,0 -59.57058,0 -208.287473,0 z"
+       id="path2984"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccc" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,27 @@
             Oath of the Gatewatch releases January 22, 2016
           </span>
         </ul>
+	<ul class="list-group">
+          <li class="list-group-item gray">
+            Theros
+            <span class="badge"><img src="img/ths.svg" /></span>
+          </li>
+          <li class="list-group-item gray">
+            Born of the Gods
+            <span class="badge"><img src="img/bng.svg" /></span>
+          </li>
+          <li class="list-group-item gray">
+            Journey into Nyx
+            <span class="badge"><img src="img/jou.svg" /></span>
+          </li>
+          <li class="list-group-item gray">
+            2015 Core Set
+            <span class="badge"><img src="img/m15.svg" /></span>
+          </li>
+          <span class="label label-warning">
+            Latest rotation out of Standard 
+          </span>
+        </ul>
       </div>
       <div class="col-md-7">
         <h2>What <em>is</em> Standard?</h2>


### PR DESCRIPTION
I thought it might be nice to have the latest sets that were rotated out of Standard listed on the page. The image below is a quick screen cap of what was added in the merge.

![image](https://cloud.githubusercontent.com/assets/664174/10745525/ed9c5ed2-7c18-11e5-8ed1-da898fe9f204.png)
