### PR TITLE
fixes issue with bouncing github logo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,10 @@ body, h1, h2, h3, h4, h5, h6 {
   font-family: "Open Sans", sans-serif;
 }
 
+body {
+  padding-bottom: 15px;
+}
+
 /*
  * tooltips
  */
@@ -124,8 +128,10 @@ hr {
   margin: 2em 0;
 }
 
-a.github {
-  position: relative;
-  bottom: 15px;
-  right: 15px;
+.github {
+  text-align: right;
+}
+
+.github > a {
+  display: inline-block;
 }

--- a/index.html
+++ b/index.html
@@ -130,13 +130,13 @@
           two-set block; <i>Dragons of Tarkir</i> and <i>Magic Origins</i> will drop in the same fashion Q4 2016.
         </p>
         <p>After that, all sets will be both released and dropped in the new style.</p>
+        <div class="github">
+          <a target="_blank" href="https://github.com/glacials/whatsinstandard">
+            <img src="img/github.png" />
+          </a>
+        </div>
       </div>
     </div>
-    <footer style="width: 100%; text-align: right; margin-top: 15px;">
-      <a class="github" target="_blank" href="https://github.com/glacials/whatsinstandard">
-        <img src="img/github.png" />
-      </a>
-    </footer>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
     <script src="bower_components/tipsy/src/javascripts/jquery.tipsy.js"></script>
     <script src="js/toggleRecentlyDropped.js"></script>


### PR DESCRIPTION
- fixes issue with moving github logo
- moved logo to bottom of right column
- removed footer

fixes: https://github.com/glacials/whatsinstandard/issues/21

* checked on mobile chrome as well

![screen shot 2016-04-13 at 8 13 50 pm](https://cloud.githubusercontent.com/assets/1621433/14516076/540660b6-01b4-11e6-9d35-ec365e344910.png)
