### PR TITLE
Add Kaladesh and Aether Revolt sets. Addresses #31

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,17 @@
             Eldritch Moon releases July 22, 2016
           </span>
         </ul>
+        <ul class="list-group">
+          <li class="list-group-item gray">
+            Kaladesh
+          </li>
+          <li class="list-group-item gray">
+            Aether Revolt
+          </li>
+          <span class="label label-default">
+            Kaladesh releases September 30, 2016
+          </span>
+        </ul>
         <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <ins class="adsbygoogle"
              style="display:block"


### PR DESCRIPTION
This is targeted to fix issue #31.

Some things I have questions about:
- I don't know of any high quality SVG set symbols for *Kaladesh* or *Aether Revolt* yet, so their icons have been omitted.
- Both sets have had their release dates announced, so I attached two `.label-default` elements to the appropriate `.list-group`. It looks okay to me, but it might not be the best solution for the annotation.

Thanks!