### PR TITLE
feat(is-standard): include clarification of what is standard

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         <h2>What <em>is</em> Standard?</h2>
         <p>
           Standard is a rotating group of <i>Magic: The Gathering</i> sets. Most sets enter Standard when they're
-          released and drop out about eighteen months later. Reprint/Masters sets are Modern sets, not standard sets.
+          released and drop out about eighteen months later. Reprint/Masters sets are Modern sets, not Standard sets.
           <sup><a target="_blank" href="http://magic.wizards.com/en/content/standard-formats-magic-gathering">1</a>
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -115,9 +115,8 @@
         <h2>What <em>is</em> Standard?</h2>
         <p>
           Standard is a rotating group of <i>Magic: The Gathering</i> sets. Most sets enter Standard when they're
-          released and drop out about eighteen months later. Some sets are labeled as <strong>Non-standard</strong> or <strong>Modern</strong> and are thus not
-          included in this group. <a class="tip" title="For example, Reprint/Masters sets are Modern sets, not standard sets."></a>
-          The sets that <i>are standard</i> are <a href="http://magic.wizards.com/en/content/standard-formats-magic-gathering">listed here.</a>
+          released and drop out about eighteen months later. Reprint/Masters sets are Modern sets, not standard sets.
+          <sup><a target="_blank" href="http://magic.wizards.com/en/content/standard-formats-magic-gathering">1</a>
         </p>
         <p>
           A <i>Standard card</i> is a card printed or reprinted into a set currently in Standard.
@@ -155,7 +154,7 @@
         <p>
           If you're coming back to <i>Magic</i> after a break, note that the way <i>Wizards</i> organizes blocks has
           recently changed. Previously, each 12-month period saw one new core set and one new three-set block; today,
-          each 12-month period sees instead two new two-set blocks (core sets are gone).<sup><a href="http://magic.wizards.com/en/articles/archive/mm/metamorphosis" target="_blank">1</a></sup>
+          each 12-month period sees instead two new two-set blocks (core sets are gone).<sup><a href="http://magic.wizards.com/en/articles/archive/mm/metamorphosis" target="_blank">2</a></sup>
         </p>
         <div class="github">
           <a target="_blank" href="https://github.com/glacials/whatsinstandard">

--- a/index.html
+++ b/index.html
@@ -113,8 +113,12 @@
       </div>
       <div class="col-md-7">
         <h2>What <em>is</em> Standard?</h2>
-        <p>Standard is a rotating group of <i>Magic: The Gathering</i> sets. Most sets enter Standard when they're
-        released and drop out about eighteen months later.</p>
+        <p>
+          Standard is a rotating group of <i>Magic: The Gathering</i> sets. Most sets enter Standard when they're
+          released and drop out about eighteen months later. Some sets are labeled as <strong>Non-standard</strong> or <strong>Modern</strong> and are thus not
+          included in this group. <a class="tip" title="For example, Reprint/Masters sets are Modern sets, not standard sets."></a>
+          The sets that <i>are standard</i> are <a href="http://magic.wizards.com/en/content/standard-formats-magic-gathering">listed here.</a>
+        </p>
         <p>
           A <i>Standard card</i> is a card printed or reprinted into a set currently in Standard.
           <a class="tip"


### PR DESCRIPTION
Includes an additional sentence clarifying that non-standard
sets are not in Standard, a tooltip with a specific example
pointing to masters sets, and a link to the official wizards
standard list.

Attempts to fix #28 
From #40 