### PR TITLE
fix set icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,16 +50,14 @@
         <div id="vue-container">
           <ul class="list-group" v-for="record in blockeditions">
             <li class="list-group-item" v-bind:class="{ 'gray list-group-item--upcoming' : isNotReleased(element.enter_date) }" v-for="element in record">
-              {{element.name}} 
-              <b-tooltip :content="element.code" placement="left" />
-                <edition-symbol :symbol="element.code" />
-              </b-tooltip>
+              {{element.name}}
+              <edition-symbol :symbol="element.code" />
             </li>
             <span class="label label-warning" v-if="record[0].exit_date">
               Until {{record[0].exit_date | moment}}
             </span>
             <span class="label label-success" v-else>
-              Until {{record[0].rough_exit_date}} 
+              Until {{record[0].rough_exit_date}}
             </span>
             <span class="label label-default" v-if="getFirstNotReleasedSet(record) !== undefined">
               {{getFirstNotReleasedSet(record)}}

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,11 @@
 var apiURL = 'http://whatsinstandard.com/api/4/sets.json'
 var symbol = Vue.component('edition-symbol', {
   props: ['symbol'],
-  template: '<span class="icon"><i class="ss" :class="imsym"></i></span>',
+  template: `
+    <span class="icon tip" :title="symbol">
+      <i class="ss" :class="imsym"></i>
+    </span>
+  `,
   data: function () {
     return {
       imsym: 'ss-' + this.symbol.toLowerCase()


### PR DESCRIPTION
Hey. I really like this site, but the lack of set icons was bothering me. I looked into it a bit and saw that they were there already, but weren't being displayed for some reason. It appears that the issue was somewhere in the bootstrap tooltip components you were using. 

To fix it, I tried to match the style used for the ban list icons. It appears the intent of the tooltip was to provide the set abbreviation on hover, so I left it as that.

This is my first time with both Vue and creating a PR across forks, so let me know what else I can do to make this mergeable.

Again -- Thanks for making this site! It has helped me on a few occasions.