### PR TITLE
Fix toggles resetting viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       </div>
       <div class="col-md-5">
         <div class="recently-dropped-toggle-container">
-          <a id="recently-dropped-toggler" href="#" class="low-distraction" onclick="toggleRecentlyDropped();">
+          <a id="recently-dropped-toggler" href="#" class="low-distraction" onclick="toggleRecentlyDropped(event);">
             show recently dropped sets
           </a>
         </div>
@@ -122,7 +122,7 @@
         </ul>
 
         <div class="ban-source-toggle-container">
-          <a id="ban-source-toggler" href="#" class="low-distraction" onclick="toggleBanSources();">
+          <a id="ban-source-toggler" href="#" class="low-distraction" onclick="toggleBanSources(event);">
             show announcements
           </a>
           <ul id="ban-source" style="display: none;">

--- a/js/toggles.js
+++ b/js/toggles.js
@@ -8,7 +8,7 @@ var hideSetsText = 'hide recently dropped sets';
 var droppedToggler = $('#recently-dropped-toggler')[0];
 var droppedSets = document.getElementById('recently-dropped');
 
-var toggleRecentlyDropped = function () {
+var toggleRecentlyDropped = function (e) {
   if (droppedSets.style.display === 'none') {
     droppedSets.style.display = 'block';
     droppedToggler.innerHTML = hideSetsText;
@@ -18,6 +18,7 @@ var toggleRecentlyDropped = function () {
     droppedToggler.innerHTML = showSetsText;
     ga('send', 'event', 'link', 'click', 'hide recently dropped sets');
   }
+  e.preventDefault();
 };
 
 /**
@@ -29,7 +30,7 @@ var hideBanSourcesText = 'hide announcements';
 var bannedSourcesToggler = $('#ban-source-toggler')[0];
 var bannedSourcesList = $('#ban-source')[0];
 
-var toggleBanSources = function () {
+var toggleBanSources = function (e) {
   if (bannedSourcesList.style.display === 'none') {
     bannedSourcesList.style.display = 'block';
     bannedSourcesToggler.innerHTML = hideBanSourcesText;
@@ -39,4 +40,5 @@ var toggleBanSources = function () {
     bannedSourcesToggler.innerHTML = showBanSourcesText;
     ga('send', 'event', 'link', 'click', 'hide ban sources');
   }
+  event.preventDefault();
 };

--- a/js/toggles.js
+++ b/js/toggles.js
@@ -40,5 +40,5 @@ var toggleBanSources = function (e) {
     bannedSourcesToggler.innerHTML = showBanSourcesText;
     ga('send', 'event', 'link', 'click', 'hide ban sources');
   }
-  event.preventDefault();
+  e.preventDefault();
 };


### PR DESCRIPTION
Fixes #68.

Issue is caused by default behaviour of the `<a>` elements used as toggles. Preventing the default behavior of the click event stops this from happening.