### PR TITLE
Add bold font for low-res screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>What's in Standard?</title>
     <meta name="description" content="A Magic: The Gathering format describer" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css' />
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css" />
     <link href="https://cdn.jsdelivr.net/npm/keyrune@latest/css/keyrune.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen" />
     <link rel="stylesheet" href="css/style.css" media="screen" />


### PR DESCRIPTION
Using bold styling without including the dedicated font for it causes ugly rendering on low-resolution screens (ie. my Macbook Air).

Including the boldface version substantially improves the look in these cases.