### PR TITLE
Add exit_dates

### DIFF
--- a/api/v5/sets.json
+++ b/api/v5/sets.json
@@ -46,7 +46,7 @@
       "block": "Kaladesh",
       "code": "KLD",
       "enter_date": "2016-09-30T00:00:00.000",
-      "exit_date": null,
+      "exit_date": "2018-10-05T00:00:00.000",
       "rough_exit_date": "Q4 2018"
     },
     {
@@ -54,7 +54,7 @@
       "block": "Kaladesh",
       "code": "AER",
       "enter_date": "2017-01-20T00:00:00.000",
-      "exit_date": null,
+      "exit_date": "2018-10-05T00:00:00.000",
       "rough_exit_date": "Q4 2018"
     },
     {
@@ -62,7 +62,7 @@
       "block": "Amonkhet",
       "code": "AKH",
       "enter_date": "2017-04-28T00:00:00.000",
-      "exit_date": null,
+      "exit_date": "2018-10-05T00:00:00.000",
       "rough_exit_date": "Q4 2018"
     },
     {
@@ -70,7 +70,7 @@
       "block": "Amonkhet",
       "code": "W17",
       "enter_date": "2017-04-28T00:00:00.000",
-      "exit_date": null,
+      "exit_date": "2018-10-05T00:00:00.000",
       "rough_exit_date": "Q4 2018"
     },
     {
@@ -78,7 +78,7 @@
       "block": "Amonkhet",
       "code": "HOU",
       "enter_date": "2017-07-14T00:00:00.000",
-      "exit_date": null,
+      "exit_date": "2018-10-05T00:00:00.000",
       "rough_exit_date": "Q4 2018"
     },
     {

--- a/api/v5/sets.json
+++ b/api/v5/sets.json
@@ -120,6 +120,14 @@
       "enter_date": "2018-10-05T00:00:00.000",
       "exit_date": null,
       "rough_exit_date": "Q4 2020"
+    },
+    {
+      "name": "Ravnica Allegiance",
+      "block": null,
+      "code": "RNA",
+      "enter_date": "2019-01-01T00:00:00.000",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2020"
     }
   ]
 }


### PR DESCRIPTION
Added exit_date to Kaladesh, Aether Revolt, Amonketh, Welcome Deck 2017 and Hour of Devistation since they will rotate when Guilds of Ravnica is added.