### PR TITLE
correct m19 set name

### DIFF
--- a/api/internal.json
+++ b/api/internal.json
@@ -112,7 +112,7 @@
       "rough_exit_date": "Q4 2019"
     },
     {
-      "name": "Core 2019",
+      "name": "Core Set 2019",
       "block": null,
       "code": "M19",
       "enter_date": "2018-07-13T00:00:00.000",


### PR DESCRIPTION
It's called `Core Set 2019` officially:
https://magic.wizards.com/en/products/core-2019

Realized that it's displayed wrongly on the webpage.