### PR TITLE
bans: add set codes to tip box

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
 					<p>Despite being in Standard sets, these cards are explicitly not allowed in Standard decks.</p>
           <p><ul class="list-group">
             <li class="list-group-item">
-              <span v-tippy class="icon tip" title="Kaladesh"><i class="ss ss-kld"></i></span>
+              <span v-tippy class="icon tip" title="Kaladesh (KLD)"><i class="ss ss-kld"></i></span>
               <div>
                 <a href="https://deckbox.org/mtg/Aetherworks+Marvel" target="_blank">
                   Aetherworks Marvel
@@ -175,7 +175,7 @@
               </small>
             </li>
             <li class="list-group-item">
-              <span v-tippy class="icon tip" title="Kaladesh"><i class="ss ss-kld"></i></span>
+              <span v-tippy class="icon tip" title="Kaladesh (KLD)"><i class="ss ss-kld"></i></span>
                 <div>
                 <a href="https://deckbox.org/mtg/Attune+with+Aether" target="_blank">
                   Attune with Aether
@@ -186,7 +186,7 @@
               </small>
             </li>
             <li class="list-group-item">
-              <span v-tippy class="icon tip" title="Kaladesh"><i class="ss ss-kld"></i></span>
+              <span v-tippy class="icon tip" title="Kaladesh (KLD)"><i class="ss ss-kld"></i></span>
               <div>
                 <a href="https://deckbox.org/mtg/Smuggler%27s+Copter" target="_blank">
                   Smuggler's Copter
@@ -197,7 +197,7 @@
               </small>
             </a>
             <li class="list-group-item">
-              <span v-tippy class="icon tip" title="Aether Revolt"><i class="ss ss-aer"></i></span>
+              <span v-tippy class="icon tip" title="Aether Revolt (AER)"><i class="ss ss-aer"></i></span>
               <div>
                 <a href="https://deckbox.org/mtg/Felidar+Guardian" target="_blank">
                   Felidar Guardian
@@ -209,7 +209,7 @@
               </small>
             </a>
             <li class="list-group-item">
-              <span v-tippy class="icon tip" title="Aether Revolt"><i class="ss ss-aer"></i></span>
+              <span v-tippy class="icon tip" title="Aether Revolt (AER)"><i class="ss ss-aer"></i></span>
               <div>
                 <a href="https://deckbox.org/mtg/Rogue+Refiner" target="_blank">
                   Rogue Refiner
@@ -220,7 +220,7 @@
               </small>
             </li>
             <li class="list-group-item">
-              <span v-tippy class="icon tip" title="Hour of Devastation"><i class="ss ss-hou"></i></span>
+              <span v-tippy class="icon tip" title="Hour of Devastation (HOU)"><i class="ss ss-hou"></i></span>
               <div>
                 <a href="https://deckbox.org/mtg/Ramunap+Ruins" target="_blank">
                   Ramunap Ruins
@@ -231,7 +231,7 @@
               </small>
             </li>
             <li class="list-group-item">
-              <span v-tippy class="icon tip" title="Ixalan"><i class="ss ss-xln"></i></span>
+              <span v-tippy class="icon tip" title="Ixalan (XLN)"><i class="ss ss-xln"></i></span>
               <div>
                 <a href="https://deckbox.org/mtg/Rampaging+Ferocidon" target="_blank">
                   Rampaging Ferocidon


### PR DESCRIPTION
fixing https://github.com/glacials/whatsinstandard/issues/96

In the list of all standard sets hovering the set icon will show it's code.
In the list of banned cards it'll show the full name instead. While that makes sense in a way, it still misses that information.
Sometimes you need to know the code over, or in addition to, the full name.

People always confused `IXL` and `XLN` for Ixalan for example.