### PR TITLE
Prevent popup from overflowing the window

### DIFF
--- a/js/cardpopup.js
+++ b/js/cardpopup.js
@@ -85,16 +85,5 @@ const tip = Tippy( '.cardname', {
 	onHidden() {
 		const content = this.querySelector( '.tippy-content' );
 		content.innerHTML = '';
-	},
-	// prevent tooltip from displaying over button
-	popperOptions: {
-		modifiers: {
-			preventOverflow: {
-				enabled: false
-			},
-			hide: {
-				enabled: false
-			}
-		}
 	}
 } );


### PR DESCRIPTION
In my testing this precaution wasn't necessary in the first place.

Addresses a concern from @glacials mentioned in https://github.com/glacials/whatsinstandard/pull/107#pullrequestreview-153857026.