### PR TITLE
Update XLN, RIX, DOM and M19 exit date to match ELD enter date

### DIFF
--- a/api/internal.json
+++ b/api/internal.json
@@ -64,7 +64,7 @@
       "code": "XLN",
       "enter_date": "2017-09-29T00:00:00.000",
       "rough_enter_date": "September 2017",
-      "exit_date": null,
+      "exit_date": "2019-10-04T00:00:00.000",
       "rough_exit_date": "Q4 2019"
     },
     {
@@ -74,7 +74,7 @@
       "code": "RIX",
       "enter_date": "2018-01-19T00:00:00.000",
       "rough_enter_date": "January 2018",
-      "exit_date": null,
+      "exit_date": "2019-10-04T00:00:00.000",
       "rough_exit_date": "Q4 2019"
     },
     {
@@ -84,7 +84,7 @@
       "code": "DOM",
       "enter_date": "2018-04-27T00:00:00.000",
       "rough_enter_date": "April 2018",
-      "exit_date": null,
+      "exit_date": "2019-10-04T00:00:00.000",
       "rough_exit_date": "Q4 2019"
     },
     {
@@ -94,7 +94,7 @@
       "code": "M19",
       "enter_date": "2018-07-13T00:00:00.000",
       "rough_enter_date": "July 2018",
-      "exit_date": null,
+      "exit_date": "2019-10-04T00:00:00.000",
       "rough_exit_date": "Q4 2019"
     },
     {

--- a/api/internal.json
+++ b/api/internal.json
@@ -141,7 +141,7 @@
       "name": "Throne of Eldraine",
       "codename": "Archery",
       "block": null,
-      "code": null,
+      "code": "ELD",
       "enter_date": "2019-10-04T00:00:00.000",
       "rough_enter_date": "October 2019",
       "exit_date": null,


### PR DESCRIPTION
- Right now the site shows XLN, RIX, DOM and M19 as leaving in 4 months, while it says that Throne of Eldraine releases in 2 months. 
Now that we know the expected release date for Throne of Eldraine, is there a reason why these 2 dates shouldn't match?
I updated their exit dates so that this is kept consistent.

- I also added Throne of Eldraine's [confirmed](https://markrosewater.tumblr.com/post/186410356343/whats-the-three-letter-abbreviation-for-thrones) three letter code 
