### PR TITLE
Fix Border on-hover issue for sets not yet in Standard

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -104,6 +104,10 @@ img.rotate-180 {
   margin-bottom: 1.5em;
 }
 
+.set-border:hover {
+  border: solid 1.3px;
+}
+
 /*
  * set symbols
  */

--- a/css/style.css
+++ b/css/style.css
@@ -105,7 +105,7 @@ img.rotate-180 {
 }
 
 .set-border:hover {
-  border: solid 1.3px;
+  border: solid 1px;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -89,7 +89,6 @@
             <div v-for="round in truncate(rounds(undropped(sets)))" class="col mb-4">
               <div class="row row-cols-1 row-cols-sm-2 border mx-0 py-3 h-100">
                 <div class="col my-3" v-for="set in round">
-                  <!-- ja;lksdjfl;kasdjfljasdlfjl;sda -->
                   <a class="text-center p-3 mb-4 card text-dark h-100 justify-content-between set-border" :class="{'bg-light': isReleased(set), 'text-muted': !isReleased(set)}" style="min-height: 5rem"
                     :href="set.code ? `https://www.scryfall.com/sets/${set.code.toLowerCase()}?utm_source=whatsinstandard` : ''">
                     <div class="w-100" v-if="set.code" :class="{'text-dark': isReleased(set), 'text-muted': !isReleased(set)}">

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
               <div class="col-md-12">
                 <div class="list-group col-md-6 mb-5 mx-auto">
                   <div class="list-group-item p-3" v-for="set in last(rounds(dropped(sets)))" style="min-height: 5rem">
-                    <div class="justify-content-between d-flex" v-tippy :title="set.code">
+                    <div class="justify-content-between d-flex set-border" v-tippy :title="set.code">
                       <a class="w-100 text-muted" :href="`https://www.scryfall.com/sets/${set.code.toLowerCase()}?utm_source=whatsinstandard`">
                         {{ set.name }}
                       </a>
@@ -89,7 +89,8 @@
             <div v-for="round in truncate(rounds(undropped(sets)))" class="col mb-4">
               <div class="row row-cols-1 row-cols-sm-2 border mx-0 py-3 h-100">
                 <div class="col my-3" v-for="set in round">
-                  <a class="text-center p-3 mb-4 card text-dark h-100 justify-content-between" :class="{'bg-light': isReleased(set), 'text-muted border-0': !isReleased(set)}" style="min-height: 5rem"
+                  <!-- ja;lksdjfl;kasdjfljasdlfjl;sda -->
+                  <a class="text-center p-3 mb-4 card text-dark h-100 justify-content-between set-border" :class="{'bg-light': isReleased(set), 'text-muted': !isReleased(set)}" style="min-height: 5rem"
                     :href="set.code ? `https://www.scryfall.com/sets/${set.code.toLowerCase()}?utm_source=whatsinstandard` : ''">
                     <div class="w-100" v-if="set.code" :class="{'text-dark': isReleased(set), 'text-muted': !isReleased(set)}">
                       {{ set.unknown ? '???' : set.name || `"${set.codename}"` }}

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,4 @@
-// var apiURL = '/api/v6/standard.json'
-var apiURL = 'https://whatsinstandard.com/api/v6/standard.json'
+var apiURL = '/api/v6/standard.json'
 var code = Vue.component('set-image', {
   props: ['code'],
   template: `

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,5 @@
-var apiURL = '/api/v6/standard.json'
+// var apiURL = '/api/v6/standard.json'
+var apiURL = 'https://whatsinstandard.com/api/v6/standard.json'
 var code = Vue.component('set-image', {
   props: ['code'],
   template: `


### PR DESCRIPTION
This fixes  [issue #156](https://github.com/glacials/whatsinstandard/issues/156) by giving all sets the faded-out border that sets currently in Standard have, and giving a thicker and darker border on-hover for every set to keep that sensation of "about to click a button." 

![border_on_released_set](https://user-images.githubusercontent.com/47371758/81348177-9f8ea100-908b-11ea-8318-7ee8fea9d74c.png)

![Illegal_Set_Border_After_Hover](https://user-images.githubusercontent.com/47371758/81348212-af0dea00-908b-11ea-93ed-2153d7b0ec60.png)
