### PR TITLE
Clarify wording on left sets button

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,10 +52,10 @@
                   <div class="flex-fill text-right">
                     <button class="btn btn-outline-light btn-sm" v-on:click.prevent="toggleRecentlyDropped">
                       <template v-if="showRecentlyDropped">
-                        Hide what just left
+                        Hide what left last
                       </template>
                       <template v-else>
-                        Show what just left
+                        Show what left last
                       </template>
                     </button>
                   </div>


### PR DESCRIPTION
Currently the button implies that the hidden sets just left shortly. But reality is that those sets left a year ago already...

![show what left one year ago](https://user-images.githubusercontent.com/9874850/94341316-9eddb380-0008-11eb-9ecb-d77721a9cebe.png)
