### PR TITLE
Hide left sets layout problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
               <div class="col-md-12">
                 <div class="list-group col-md-6 mb-5 mx-auto">
                   <div class="list-group-item p-3" v-for="set in last(rounds(dropped(sets)))" style="min-height: 5rem">
-                    <div class="justify-content-between d-flex set-border" v-tippy :title="set.code">
+                    <div class="justify-content-between d-flex" v-tippy :title="set.code">
                       <a class="w-100 text-muted" :href="`https://www.scryfall.com/sets/${set.code.toLowerCase()}?utm_source=whatsinstandard`">
                         {{ set.name }}
                       </a>

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,7 @@
-var apiURL = '/api/v6/standard.json'
+// var apiURL = '/api/v6/standard.json'
+
+// hit the deployed api for testing
+var apiURL = 'https://whatsinstandard.com/api/v6/standard.json';
 var code = Vue.component('set-image', {
   props: ['code'],
   template: `

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,4 @@
-// var apiURL = '/api/v6/standard.json'
-
-// hit the deployed api for testing
-var apiURL = 'https://whatsinstandard.com/api/v6/standard.json';
+var apiURL = '/api/v6/standard.json'
 var code = Vue.component('set-image', {
   props: ['code'],
   template: `


### PR DESCRIPTION
Fixes: #165 

The `.set-border` class that is being used for the sets that are in Standard, or about to be, was applied to sets that have left. This added the border, and also applied a "jumping" effect. Just removing that selector got rid of the borders and the jumping for me, locally. 

Let me know if this looks okay for you, or if there is anything else I should do. 