### PR TITLE
Add known data about Strixhaven and Adventures in the Forgotten Realms.

### DIFF
--- a/api/internal.json
+++ b/api/internal.json
@@ -196,6 +196,26 @@
       "rough_enter_date": "Q1 2021",
       "exit_date": null,
       "rough_exit_date": "Q4 2022"
+    },
+    {
+      "name": "Strixhaven: School of Mages",
+      "codename": "Fencing",
+      "block": null,
+      "code": "STX",
+      "enter_date": null,
+      "rough_enter_date": "Q2 2021",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2022"
+    },
+    {
+      "name": "Dungeons & Dragons: Adventures in the Forgotten Realms",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q3 2021",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2022"
     }
   ],
   "bans": [

--- a/api/v5/generate.js
+++ b/api/v5/generate.js
@@ -19,7 +19,7 @@ module.exports = {
         "sets": [],
         "bans": []
       }
-      inputJSON.sets.filter(set => set.name !== null && set.code !== null && set.enter_date !== null).forEach(set => {
+      inputJSON.sets.filter(set => set.name !== null && set.code !== null).forEach(set => {
         outputJSON.sets.push({
           "name": set.name,
           "block": set.block,

--- a/api/v5/generate.js
+++ b/api/v5/generate.js
@@ -19,7 +19,7 @@ module.exports = {
         "sets": [],
         "bans": []
       }
-      inputJSON.sets.filter(set => set.name !== null && set.code !== null).forEach(set => {
+      inputJSON.sets.filter(set => set.name !== null && set.code !== null && set.enter_date !== null).forEach(set => {
         outputJSON.sets.push({
           "name": set.name,
           "block": set.block,

--- a/test/api.js
+++ b/test/api.js
@@ -129,20 +129,25 @@ describe("API", () => {
           describe("enter date", () => {
             const enterDate = set.enter_date
 
-            it("should be a string", () => {
-              expect(enterDate).to.be.a.string
+            it("should be a string or null", () => {
+              expect(enterDate || "").to.be.a.string
             })
 
-            it("should be an ISO 8601 datetime", () => {
-              expect(Date.parse(enterDate)).to.be.a('number')
+            it("should be an ISO 8601 datetime if present", () => {
+              expect(Date.parse(enterDate || "1970-01-01T00:00:00.000")).to.be.a('number')
             })
 
-            it("should represent midnight", () => {
-              expect(enterDate).to.contain("00:00:00.00")
+            it("should represent midnight if present", () => {
+              expect(enterDate || "1970-01-01T00:00:00.000").to.contain("00:00:00.00")
             })
 
-            it("should not attach a timezone", () => {
-              expect(enterDate.substring(enterDate.length - 12, enterDate.length - 1)).to.equal("00:00:00.00")
+            it("should not attach a timezone if present", () => {
+              expect(
+                (enterDate || "1970-01-01T00:00:00.000").substring(
+                  (enterDate || "1970-01-01T00:00:00.000").length - 12,
+                  (enterDate || "1970-01-01T00:00:00.000").length - 1
+                )
+              ).to.equal("00:00:00.00")
             })
           })
 


### PR DESCRIPTION
I added Names and rough dates for the two sets following Kaldheim.

I also had to fix the v5 generator, because it was failing tests.

Didn't add the Q4 set(s), because I don't know how we want to represent them yet. I think we just wait for WotC to give us more details.