### PR TITLE
Add initial data for 2022 Standard sets

### DIFF
--- a/api/internal.json
+++ b/api/internal.json
@@ -236,6 +236,46 @@
       "rough_enter_date": "Q4 2021",
       "exit_date": null,
       "rough_exit_date": "Q4 2023"
+    },
+    {
+      "name": "Kamigawa: Neon Dynasty",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q1 2022",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2023"
+    },
+        {
+      "name": "Streets of New Capenna",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q2 2022",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2023"
+    },
+    {
+      "name": "Dominaria United",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q3 2022",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2024"
+    },
+    {
+      "name": "The Brothers' War",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q4 2022",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2024"
     }
   ],
   "bans": [


### PR DESCRIPTION
Source: https://magic.wizards.com/en/articles/archive/feature/what-happened-magic-showcase-2021-08-24

![2022 Standard sets](https://user-images.githubusercontent.com/3404787/133497068-57bea5e3-8dd8-458f-a0ac-3f2f05a814ce.jpg)
