### PR TITLE
Add Brothers War release date

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -272,7 +272,7 @@
       "codename": null,
       "block": null,
       "code": null,
-      "enter_date": null,
+      "enter_date": "2022-11-18T00:00:00.000",
       "rough_enter_date": "Q4 2022",
       "exit_date": null,
       "rough_exit_date": "Q4 2024"


### PR DESCRIPTION
Source: https://magic.wizards.com/en/articles/archive/news/your-sneak-peek-double-masters-2022-dominaria-united-and-beyond-2022-05-12 (Literally the same article as #231)