### PR TITLE
Add The Meathook Massacre to banned cards

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -405,6 +405,13 @@
       "set_code": "KHM",
       "reason": "Banned for being too efficient in monocolor aggro decks.",
       "announcement_url": "https://magic.wizards.com/en/articles/archive/news/january-25-2022-banned-and-restricted-announcement"
+    },
+    {
+      "card_name": "The Meathook Massacre",
+      "card_image_url": "https://cards.scryfall.io/large/front/0/8/08950015-eee5-4327-888c-82dfd13bb9ad.jpg",
+      "set_code": "MID",
+      "reason": "Banned for the color black's play rate among competitive decks being a bit too high.",
+      "announcement_url": "https://magic.wizards.com/en/articles/archive/news/october-10-2022-banned-and-restricted-announcement"
     }
   ]
 }


### PR DESCRIPTION
Closes #238

Source: https://magic.wizards.com/en/articles/archive/news/october-10-2022-banned-and-restricted-announcement