### PR TITLE
Update Phyrexia: All Will Be One enter date

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -282,7 +282,7 @@
       "codename": null,
       "block": null,
       "code": "ONE",
-      "enter_date": "2023-02-10T00:00:00.000",
+      "enter_date": "2023-02-03T00:00:00.000",
       "rough_enter_date": "Q1 2023",
       "exit_date": null,
       "rough_exit_date": "Q4 2024"


### PR DESCRIPTION
The enter date is back to 2023-02-03, as WotC changed Standard format legality shifts.

Source: https://magic.wizards.com/en/news/announcements/format-legality-shifts-to-prerelease-with-phyrexia-all-will-be-one