### PR TITLE
Add March of the Machine: The Aftermath set code and enter date

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -301,9 +301,9 @@
       "name": "March of the Machine: The Aftermath",
       "codename": null,
       "block": null,
-      "code": null,
-      "enter_date": null,
-      "rough_enter_date": "Q3 2023",
+      "code": "MAT",
+      "enter_date": "2023-05-12T00:00:00.000",
+      "rough_enter_date": "Q2 2023",
       "exit_date": null,
       "rough_exit_date": "Q4 2025"
     },


### PR DESCRIPTION
Source: https://magic.wizards.com/en/news/announcements/march-of-the-machine-arrives-in-2023