### PR TITLE
Fix March of the Machine: The Aftermath rough exit date

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -305,7 +305,7 @@
       "enter_date": "2023-05-12T00:00:00.000",
       "rough_enter_date": "Q2 2023",
       "exit_date": null,
-      "rough_exit_date": "Q4 2025"
+      "rough_exit_date": "Q4 2024"
     },
         {
       "name": "Wilds of Eldraine",


### PR DESCRIPTION
It belongs to the same Standard rotation as March of the Machine.

> MOM: Aftermath is a new thing and not a normal expansion.

Source: https://markrosewater.tumblr.com/post/700372166964822016/what-are-you-counting-exactly-sorry-i-didnt