### PR TITLE
Standard rotation is every 3 years from now on

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -225,7 +225,7 @@
       "enter_date": "2021-09-24T00:00:00.000",
       "rough_enter_date": "Q3 2021",
       "exit_date": null,
-      "rough_exit_date": "Q4 2023"
+      "rough_exit_date": "Q4 2024"
     },
     {
       "name": "Innistrad: Crimson Vow",
@@ -235,7 +235,7 @@
       "enter_date": "2021-11-19T00:00:00.000",
       "rough_enter_date": "Q4 2021",
       "exit_date": null,
-      "rough_exit_date": "Q4 2023"
+      "rough_exit_date": "Q4 2024"
     },
     {
       "name": "Kamigawa: Neon Dynasty",
@@ -245,7 +245,7 @@
       "enter_date": "2022-02-18T00:00:00.000",
       "rough_enter_date": "Q1 2022",
       "exit_date": null,
-      "rough_exit_date": "Q4 2023"
+      "rough_exit_date": "Q4 2024"
     },
     {
       "name": "Streets of New Capenna",
@@ -255,7 +255,7 @@
       "enter_date": "2022-04-29T00:00:00.000",
       "rough_enter_date": "Q2 2022",
       "exit_date": null,
-      "rough_exit_date": "Q4 2023"
+      "rough_exit_date": "Q4 2024"
     },
     {
       "name": "Dominaria United",
@@ -265,7 +265,7 @@
       "enter_date": "2022-09-09T00:00:00.000",
       "rough_enter_date": "Q3 2022",
       "exit_date": null,
-      "rough_exit_date": "Q4 2024"
+      "rough_exit_date": "Q4 2025"
     },
     {
       "name": "The Brothers' War",
@@ -275,7 +275,7 @@
       "enter_date": "2022-11-18T00:00:00.000",
       "rough_enter_date": "Q4 2022",
       "exit_date": null,
-      "rough_exit_date": "Q4 2024"
+      "rough_exit_date": "Q4 2025"
     },
     {
       "name": "Phyrexia: All Will Be One",
@@ -285,7 +285,7 @@
       "enter_date": "2023-02-03T00:00:00.000",
       "rough_enter_date": "Q1 2023",
       "exit_date": null,
-      "rough_exit_date": "Q4 2024"
+      "rough_exit_date": "Q4 2025"
     },
     {
       "name": "March of the Machine",
@@ -295,7 +295,7 @@
       "enter_date": "2023-04-14T00:00:00.000",
       "rough_enter_date": "Q2 2023",
       "exit_date": null,
-      "rough_exit_date": "Q4 2024"
+      "rough_exit_date": "Q4 2025"
     },
     {
       "name": "March of the Machine: The Aftermath",
@@ -305,7 +305,7 @@
       "enter_date": "2023-05-12T00:00:00.000",
       "rough_enter_date": "Q2 2023",
       "exit_date": null,
-      "rough_exit_date": "Q4 2024"
+      "rough_exit_date": "Q4 2025"
     },
         {
       "name": "Wilds of Eldraine",
@@ -315,7 +315,7 @@
       "enter_date": "2023-09-08T00:00:00.000",
       "rough_enter_date": "Q4 2023",
       "exit_date": null,
-      "rough_exit_date": "Q4 2025"
+      "rough_exit_date": "Q4 2026"
     },
     {
       "name": "The Lost Caverns of Ixalan",
@@ -325,7 +325,7 @@
       "enter_date": null,
       "rough_enter_date": "Q1 2024",
       "exit_date": null,
-      "rough_exit_date": "Q4 2025"
+      "rough_exit_date": "Q4 2026"
     }
   ],
   "bans": [


### PR DESCRIPTION
See [Revitalizing Standard](https://magic.wizards.com/en/news/announcements/revitalizing-standard) and [Updates to Standard and Alchemy on MTG Arena](https://magic.wizards.com/en/news/mtg-arena/updates-to-standard-and-alchemy-on-mtg-arena).

Part of #259