### PR TITLE
Add bans from 2023-05-29: Fable, Invoke Despair, and Bankbuster

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -424,14 +424,14 @@
       "card_name": "Invoke Despair",
       "card_image_url": "https://cards.scryfall.io/large/front/3/5/35af9d5c-4449-4549-b549-c3ba4a67dee0.jpg?1685368727",
       "set_code": "NEO",
-      "reason": "Banned due to its power level and negative impact on card diversity in black-based decks.",
+      "reason": "Banned for its power level and negative impact on card diversity in black-based decks.",
       "announcement_url": "https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement"
     },
     {
       "card_name": "Reckoner Bankbuster",
       "card_image_url": "https://cards.scryfall.io/large/front/2/7/279acd17-6c17-427b-a69d-fc02442ff4a3.jpg?1685368706",
       "set_code": "NEO",
-      "reason": "Banned to promote more diversity and give power back to other types of cards in different colors.",
+      "reason": "Banned for reducing card diversity and to give power back to other types of cards in different colors.",
       "announcement_url": "https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement"
     }
   ]

--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -412,6 +412,27 @@
       "set_code": "MID",
       "reason": "Banned for the color black's play rate among competitive decks being a bit too high.",
       "announcement_url": "https://magic.wizards.com/en/articles/archive/news/october-10-2022-banned-and-restricted-announcement"
+    },
+    {
+      "card_name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
+      "card_image_url": "https://cards.scryfall.io/large/front/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1685368758",
+      "set_code": "NEO",
+      "reason": "Banned for being too efficient in black-red decks.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement"
+    },
+    {
+      "card_name": "Invoke Despair",
+      "card_image_url": "https://cards.scryfall.io/large/front/3/5/35af9d5c-4449-4549-b549-c3ba4a67dee0.jpg?1685368727",
+      "set_code": "NEO",
+      "reason": "Banned due to its power level and negative impact on card diversity in black-based decks.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement"
+    },
+    {
+      "card_name": "Reckoner Bankbuster",
+      "card_image_url": "https://cards.scryfall.io/large/front/2/7/279acd17-6c17-427b-a69d-fc02442ff4a3.jpg?1685368706",
+      "set_code": "NEO",
+      "reason": "Banned to promote more diversity and give power back to other types of cards in different colors.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement"
     }
   ]
 }


### PR DESCRIPTION
Fable of the Mirror-Breaker, Invoke Despair, and Reckoner Bankbuster are now banned.

Source: https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement