### PR TITLE
Update rough enter dates and add 2024 sets

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -326,6 +326,46 @@
       "rough_enter_date": "Q4 2023",
       "exit_date": null,
       "rough_exit_date": "Q4 2026"
+    },
+    {
+      "name": "Murders at Karlov Manner",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q1 2024",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2026"
+    },
+    {
+      "name": "Outlaws of Thunder Junction",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q2 2024",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2026"
+    },
+    {
+      "name": "Bloomburrow",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q3 2024",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2027"
+    },
+    {
+      "name": "Duskmourn: House of Horror",
+      "codename": null,
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q4 2024",
+      "exit_date": null,
+      "rough_exit_date": "Q4 2027"
     }
   ],
   "bans": [

--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -313,7 +313,7 @@
       "block": null,
       "code": "WOE",
       "enter_date": "2023-09-08T00:00:00.000",
-      "rough_enter_date": "Q4 2023",
+      "rough_enter_date": "Q3 2023",
       "exit_date": null,
       "rough_exit_date": "Q4 2026"
     },
@@ -323,7 +323,7 @@
       "block": null,
       "code": null,
       "enter_date": null,
-      "rough_enter_date": "Q1 2024",
+      "rough_enter_date": "Q4 2023",
       "exit_date": null,
       "rough_exit_date": "Q4 2026"
     }


### PR DESCRIPTION
Source enter dates: https://magic.wizards.com/en/news/announcements/next-year-of-magic-wizards-presents-2022-08-18
Source 2024 sets: https://wpn.wizards.com/en/news/magic-at-gencon-celebrating-30-years-and-casting-foresee-on-years-ahead