### PR TITLE
Add Leyline of Resonance ban in Arena BO1

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -543,6 +543,13 @@
       "set_code": "NEO",
       "reason": "Banned to increase diversity of card advantage options among the colors.",
       "announcement_url": "https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement"
+    },
+    {
+      "card_name": "Leyline of Resonance",
+      "card_image_url": "https://cards.scryfall.io/large/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg?1729596723",
+      "set_code": "DSK",
+      "reason": "Banned in MTG Arena Standard Best-of-One Constructed formats for creating non-interactive win conditions within two turns.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/mtg-arena-banned-and-restricted-announcement-october-22-2024"
     }
   ]
 }


### PR DESCRIPTION
Source: https://magic.wizards.com/en/news/announcements/mtg-arena-banned-and-restricted-announcement-october-22-2024

This is a narrow ban that doesn't affect all of Standard - only MTG Arena, and only Best-of-One Standard Constructed formats.

This is apparently the [first MTG Arena-exclusive ban in five years](https://mtgrocks.com/leyline-of-resonance-ban-mtg/). If this becomes a pattern, and you *do* want to include Arena-only bans, it might be worth adding some kind of decoration for them to highlight that they don't apply to paper Standard. Idk if that's warranted for a one-off, though, so I didn't do the work here.

Anyway, feel free to close this PR if you don't think it's appropriate for `whatsinstandard` since it doesn't affect paper or best-of-three formats. Just figured I'd offer!