### PR TITLE
Change to the new Rotation 2027

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -315,7 +315,7 @@
       "enter_date": "2023-09-08T00:00:00.000",
       "rough_enter_date": "Q3 2023",
       "exit_date": null,
-      "rough_exit_date": "Q4 2026"
+      "rough_exit_date": "Q1 2027"
     },
     {
       "name": "The Lost Caverns of Ixalan",
@@ -325,7 +325,7 @@
       "enter_date": "2023-11-17T00:00:00.000",
       "rough_enter_date": "Q4 2023",
       "exit_date": null,
-      "rough_exit_date": "Q4 2026"
+      "rough_exit_date": "Q1 2027"
     },
     {
       "name": "Murders at Karlov Manor",
@@ -335,7 +335,7 @@
       "enter_date": "2024-02-09T00:00:00.000",
       "rough_enter_date": "Q1 2024",
       "exit_date": null,
-      "rough_exit_date": "Q4 2026"
+      "rough_exit_date": "Q1 2027"
     },
     {
       "name": "Outlaws of Thunder Junction",
@@ -345,7 +345,7 @@
       "enter_date": "2024-04-19T00:00:00.000",
       "rough_enter_date": "Q2 2024",
       "exit_date": null,
-      "rough_exit_date": "Q4 2026"
+      "rough_exit_date": "Q1 2027"
     },
     {
       "name": "Bloomburrow",
@@ -355,7 +355,7 @@
       "enter_date": "2024-08-02T00:00:00.000",
       "rough_enter_date": "Q3 2024",
       "exit_date": null,
-      "rough_exit_date": "Q4 2027"
+      "rough_exit_date": "Q1 2027"
     },
     {
       "name": "Duskmourn: House of Horror",
@@ -365,7 +365,7 @@
       "enter_date": "2024-09-27T00:00:00.000",
       "rough_enter_date": "Q3 2024",
       "exit_date": null,
-      "rough_exit_date": "Q4 2027"
+      "rough_exit_date": "Q1 2027"
     },
     {
       "name": "Magic: the Gathering Foundations",
@@ -375,17 +375,17 @@
       "enter_date": "2024-11-15T00:00:00.000",
       "rough_enter_date": "Q4 2024",
       "exit_date": null,
-      "rough_exit_date": "Q4 2029"
+      "rough_exit_date": "Q1 2030"
     },
     {
       "name": "Aetherdrift",
       "codename": "Tennis",
       "block": null,
       "code": "DFT",
-      "enter_date": "2025-02-07T00:00:00.000",
+      "enter_date": "2025-02-14T00:00:00.000",
       "rough_enter_date": "Q1 2025",
       "exit_date": null,
-      "rough_exit_date": "Q4 2027"
+      "rough_exit_date": "Q1 2028"
     },
     {
       "name": "Tarkir: Dragonstorm",
@@ -395,7 +395,17 @@
       "enter_date": "2025-04-11T00:00:00.000",
       "rough_enter_date": "Q2 2025",
       "exit_date": null,
-      "rough_exit_date": "Q4 2027"
+      "rough_exit_date": "Q1 2028"
+    },
+    {
+      "name": "Universes Beyond: Final Fantasy",
+      "codename": null,
+      "block": null,
+      "code": "FIN",
+      "enter_date": "2025-06-13T00:00:00.000",
+      "rough_enter_date": "Q2 2025",
+      "exit_date": null,
+      "rough_exit_date": "Q1 2028"
     },
     {
       "name": "Edge of Eternities",
@@ -405,7 +415,27 @@
       "enter_date": "2025-08-01T00:00:00.000",
       "rough_enter_date": "Q3 2025",
       "exit_date": null,
-      "rough_exit_date": "Q4 2028"
+      "rough_exit_date": "Q1 2028"
+    },
+    {
+      "name": "Universes Beyond: Marvel's Spider-Man",
+      "codename": null,
+      "block": null,
+      "code": "SPM",
+      "enter_date": null,
+      "rough_enter_date": "Q4 2025",
+      "exit_date": null,
+      "rough_exit_date": "Q1 2028"
+    },
+    {
+      "name": null,
+      "codename": "UUB",
+      "block": null,
+      "code": null,
+      "enter_date": null,
+      "rough_enter_date": "Q4 2025",
+      "exit_date": null,
+      "rough_exit_date": "Q1 2028"
     },
     {
       "name": null,
@@ -413,9 +443,9 @@
       "block": null,
       "code": null,
       "enter_date": null,
-      "rough_enter_date": "Q4 2025",
+      "rough_enter_date": "Q1 2026",
       "exit_date": null,
-      "rough_exit_date": "Q4 2028"
+      "rough_exit_date": "Q1 2029"
     },
     {
       "name": null,
@@ -423,9 +453,9 @@
       "block": null,
       "code": null,
       "enter_date": null,
-      "rough_enter_date": "Q1 2026",
+      "rough_enter_date": "Q2 2026",
       "exit_date": null,
-      "rough_exit_date": "Q4 2028"
+      "rough_exit_date": "Q1 2029"
     },
     {
       "name": null,
@@ -435,7 +465,7 @@
       "enter_date": null,
       "rough_enter_date": "Q2 2026",
       "exit_date": null,
-      "rough_exit_date": "Q4 2028"
+      "rough_exit_date": "Q1 2029"
     }
   ],
   "bans": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@popperjs/core": "^2.9.2",
         "bootstrap": "^5.3",
-        "keyrune": "^3.14.0",
+        "keyrune": "^3.15.0",
         "node": "^20",
         "npm-font-open-sans": "^1.1.0",
         "vue": "^3.3.4",
@@ -1820,9 +1820,10 @@
       "dev": true
     },
     "node_modules/keyrune": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/keyrune/-/keyrune-3.14.0.tgz",
-      "integrity": "sha512-KAWOuyuRxA8ekx7V5pxXBu9CQKC19NqjfgFenGU8zyfeSly77f41mwXFvyDnXaoYaa5QHAbGzlVWleMfsMJ/yg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/keyrune/-/keyrune-3.15.0.tgz",
+      "integrity": "sha512-crhtY2CwJ0iNfSnIKRJaYfMy0pWBpNi0azaQCn8Nm8nLAX55ar5yeSKgzqNrSgZX4QIDgAiUo76VQrfpDOP1Gg==",
+      "license": "(OFL-1.1 AND GPL-3.0-only)",
       "engines": {
         "node": "*"
       }
@@ -4359,9 +4360,9 @@
       "dev": true
     },
     "keyrune": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/keyrune/-/keyrune-3.14.0.tgz",
-      "integrity": "sha512-KAWOuyuRxA8ekx7V5pxXBu9CQKC19NqjfgFenGU8zyfeSly77f41mwXFvyDnXaoYaa5QHAbGzlVWleMfsMJ/yg=="
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/keyrune/-/keyrune-3.15.0.tgz",
+      "integrity": "sha512-crhtY2CwJ0iNfSnIKRJaYfMy0pWBpNi0azaQCn8Nm8nLAX55ar5yeSKgzqNrSgZX4QIDgAiUo76VQrfpDOP1Gg=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@popperjs/core": "^2.9.2",
     "bootstrap": "^5.3",
-    "keyrune": "^3.14.0",
+    "keyrune": "^3.15.0",
     "node": "^20",
     "npm-font-open-sans": "^1.1.0",
     "vue": "^3.3.4",

--- a/web/src/types/card/Round.js
+++ b/web/src/types/card/Round.js
@@ -47,7 +47,7 @@ export default class Round {
     return rounds
       .filter((round) => !round.isDropped())
       .filter((round) => round.isFullyReleased())
-      .concat(rounds.filter((round) => !round.isFullyReleased())[0]);
+      .concat(rounds.filter((round) => !round.isFullyReleased()).slice(0, 2));
   }
 
   /**


### PR DESCRIPTION
- Modified the timeline based on the new rotation rules
https://magic.wizards.com/en/news/announcements/aligning-the-universes-making-all-our-sets-legal-in-all-our-formats
- Update keyrune version
- Show one more rotation round (temporary I think)

PS: Maybe the rotation date can be clearer now, such as when the first set of 2027 releases?