### PR TITLE
Add The Big Score (BIG) to set list

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -348,6 +348,16 @@
       "rough_exit_date": "Q1 2027"
     },
     {
+      "name": "The Big Score",
+      "codename": "Quilting Epilogue",
+      "block": null,
+      "code": "BIG",
+      "enter_date": "2024-04-19T00:00:00.000",
+      "rough_enter_date": "Q2 2024",
+      "exit_date": null,
+      "rough_exit_date": "Q1 2027"
+    },
+    {
       "name": "Bloomburrow",
       "codename": "Rugby",
       "block": null,


### PR DESCRIPTION
Per issue #300, this pull request is to add the bonus sheet set [_The Big Score_](https://mtg.fandom.com/wiki/Outlaws_of_Thunder_Junction/The_Big_Score) (BIG) from [_Outlaws of Thunder Junction_](https://mtg.fandom.com/wiki/Outlaws_of_Thunder_Junction) (OTJ).

The BIG bonus sheet contains 30 Standard legal cards (all mythic rare). Due to the way the set came about, _Outlaws of Thunder Junction_ has another, non-Standard legal bonus sheet - [_Breaking News_](https://mtg.fandom.com/wiki/Outlaws_of_Thunder_Junction/Breaking_News) - and having the two be lumped under OTJ in the whatsinstandard listmay cause confusion for players unaware of the difference.