### PR TITLE
Updates for new set details - Wrestling + Yachting

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -264,7 +264,7 @@
       "code": "DMU",
       "enter_date": "2022-09-09T00:00:00.000",
       "rough_enter_date": "Q3 2022",
-      "exit_date": null,
+      "exit_date": "2025-08-01T00:00:00.000",
       "rough_exit_date": "Q4 2025"
     },
     {
@@ -274,7 +274,7 @@
       "code": "BRO",
       "enter_date": "2022-11-18T00:00:00.000",
       "rough_enter_date": "Q4 2022",
-      "exit_date": null,
+      "exit_date": "2025-08-01T00:00:00.000",
       "rough_exit_date": "Q4 2025"
     },
     {
@@ -284,7 +284,7 @@
       "code": "ONE",
       "enter_date": "2023-02-03T00:00:00.000",
       "rough_enter_date": "Q1 2023",
-      "exit_date": null,
+      "exit_date": "2025-08-01T00:00:00.000",
       "rough_exit_date": "Q4 2025"
     },
     {
@@ -294,7 +294,7 @@
       "code": "MOM",
       "enter_date": "2023-04-14T00:00:00.000",
       "rough_enter_date": "Q2 2023",
-      "exit_date": null,
+      "exit_date": "2025-08-01T00:00:00.000",
       "rough_exit_date": "Q4 2025"
     },
     {
@@ -304,7 +304,7 @@
       "code": "MAT",
       "enter_date": "2023-05-12T00:00:00.000",
       "rough_enter_date": "Q2 2023",
-      "exit_date": null,
+      "exit_date": "2025-08-01T00:00:00.000",
       "rough_exit_date": "Q4 2025"
     },
     {
@@ -379,7 +379,7 @@
     },
     {
       "name": "Magic: The Gathering Foundations",
-      "codename": null,
+      "codename": "Farmer",
       "block": null,
       "code": "FDN",
       "enter_date": "2024-11-15T00:00:00.000",
@@ -408,7 +408,7 @@
       "rough_exit_date": "Q1 2028"
     },
     {
-      "name": "Universes Beyond: Final Fantasy",
+      "name": "Magic: The Gathering—FINAL FANTASY",
       "codename": null,
       "block": null,
       "code": "FIN",
@@ -428,37 +428,37 @@
       "rough_exit_date": "Q1 2028"
     },
     {
-      "name": "Universes Beyond: Marvel's Spider-Man",
+      "name": "Marvel’s Spider-Man",
       "codename": null,
       "block": null,
       "code": "SPM",
-      "enter_date": null,
+      "enter_date": "2025-09-26T00:00:00.000",
       "rough_enter_date": "Q4 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028"
     },
     {
-      "name": null,
-      "codename": "UUB",
+      "name": "Avatar: The Last Airbender"
+      "codename": null,
       "block": null,
-      "code": null,
-      "enter_date": null,
+      "code": "TLA",
+      "enter_date": "2025-11-21T00:00:00.000",
       "rough_enter_date": "Q4 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028"
     },
     {
-      "name": null,
+      "name": "Lorwyn Eclipsed"
       "codename": "Wrestling",
       "block": null,
       "code": null,
-      "enter_date": null,
+      "enter_date": "2026-01-23T00:00:00.000",
       "rough_enter_date": "Q1 2026",
       "exit_date": null,
       "rough_exit_date": "Q1 2029"
     },
     {
-      "name": null,
+      "name": "Secrets of Strixhaven"
       "codename": "Yachting",
       "block": null,
       "code": null,


### PR DESCRIPTION
Hi @glacials,
The recent MagicCon Las Vegas 2025 has brought with it some more information on future sets.

We now have names for the first two sets of 2026:
- "Wrestling" is _Lorwyn Eclipsed_.
- "Yachting" is _Secrets of Strixhaven_.

We have the release dates for:
- Edge of Eternities
- Marvel's Spider-Man
- Avatar: The Last Airbender
- Lorwyn Eclipsed

The release date for EOE means we also have the exact rotation dates for:
- Dominaria United
- The Brothers' War
- Phyrexia: All Will Be One
- March of the Machine
- March of the Machine: The Aftermath