### PR TITLE
B&R update - June 30, 2025

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -583,6 +583,55 @@
       "set_code": "NEO",
       "reason": "Banned to increase diversity of card advantage options among the colors.",
       "announcement_url": "https://magic.wizards.com/en/news/announcements/may-29-2023-banned-and-restricted-announcement"
+    },
+    {
+      "card_name": "Hopeless Nightmare",
+      "card_image_url": "https://cards.scryfall.io/large/front/2/c/2c2ee817-9ca9-4f09-bc71-7994c19a9470.jpg",
+      "set_code": "WOE",
+      "reason": "Banned for its poor play patterns in self-bounce decks.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025"
+    },
+    {
+      "card_name": "Monstrous Rage",
+      "card_image_url": "https://cards.scryfall.io/large/front/e/e/eef5a0ae-5907-42c9-a097-3f973737e392.jpg",
+      "set_code": "WOE",
+      "reason": "Banned for enabling combo-style aggro decks and putting players under too much pressure too quickly.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025"
+    },
+    {
+      "card_name": "Up the Beanstalk",
+      "card_image_url": "https://cards.scryfall.io/large/front/2/d/2d5e991f-23b2-4db0-a452-7755125b1fd2.jpg",
+      "set_code": "WOE",
+      "reason": "Banned for its power level being higher than is healthy for current and future Standard metagame environments.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025"
+    },
+        {
+      "card_name": "Abuelo's Awakening",
+      "card_image_url": "https://cards.scryfall.io/large/front/f/9/f93b725e-2b9c-4830-ac54-b2562afe09bb.jpg",
+      "set_code": "LCI",
+      "reason": "Banned for its ability to cheat Omniscience into play as early as turn four, far faster than desired by Design.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025"
+    },
+    {
+      "card_name": "This Town Ain't Big Enough",
+      "card_image_url": "https://cards.scryfall.io/large/front/b/b/bb206e27-da4d-4abe-9d8c-6d18c5f2f52a.jpg",
+      "set_code": "OTJ",
+      "reason": "Banned due to the unfun play patterns it creates when paired with Stormchaser's Talent.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025"
+    },
+    {
+      "card_name": "Heartfire Hero",
+      "card_image_url": "https://cards.scryfall.io/large/front/4/8/48ace959-66b2-40c8-9bff-fd7ed9c99a82.jpg",
+      "set_code": "BLB",
+      "reason": "Banned for putting players under too much pressure too quickly and for its resiliency to many kinds of removal due to its dies trigger.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025"
+    },
+    {
+      "card_name": "Cori-Steel Cutter",
+      "card_image_url": "https://cards.scryfall.io/large/front/4/9/490eb213-9ae2-4b45-abec-6f1dfc83792a.jpg",
+      "set_code": "TDM",
+      "reason": "Banned for its power level being higher than is healthy for current and future Standard metagame environments.",
+      "announcement_url": "https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025"
     }
   ]
 }


### PR DESCRIPTION
Hi @glacials,
This pull request is to update the cards banned in Standard after today's B&R announcement. Seven cards have been axed.
- **Cori-Steel Cutter** is banned. 
- **Abuelo's Awakening** is banned. 
- **Monstrous Rage** is banned. 
- **Heartfire Hero** is banned. 
- **Up the Beanstalk** is banned. 
- **Hopeless Nightmare** is banned. 
- **This Town Ain't Big Enough** is banned. 

Source: https://magic.wizards.com/en/news/announcements/banned-and-restricted-june-30-2025

I'm not a huge Standard player so feel free to re-write my "reasons" comments if they're not clear/concise/accurate.