### PR TITLE
Rotation date - updated

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -264,8 +264,8 @@
       "code": "DMU",
       "enter_date": "2022-09-09T00:00:00.000",
       "rough_enter_date": "Q3 2022",
-      "exit_date": "2025-08-01T00:00:00.000",
-      "rough_exit_date": "Q4 2025"
+      "exit_date": "2025-07-29T00:00:00.000",
+      "rough_exit_date": "Q3 2025"
     },
     {
       "name": "The Brothers' War",
@@ -274,8 +274,8 @@
       "code": "BRO",
       "enter_date": "2022-11-18T00:00:00.000",
       "rough_enter_date": "Q4 2022",
-      "exit_date": "2025-08-01T00:00:00.000",
-      "rough_exit_date": "Q4 2025"
+      "exit_date": "2025-07-29T00:00:00.000",
+      "rough_exit_date": "Q3 2025"
     },
     {
       "name": "Phyrexia: All Will Be One",
@@ -284,8 +284,8 @@
       "code": "ONE",
       "enter_date": "2023-02-03T00:00:00.000",
       "rough_enter_date": "Q1 2023",
-      "exit_date": "2025-08-01T00:00:00.000",
-      "rough_exit_date": "Q4 2025"
+      "exit_date": "2025-07-29T00:00:00.000",
+      "rough_exit_date": "Q3 2025"
     },
     {
       "name": "March of the Machine",
@@ -294,8 +294,8 @@
       "code": "MOM",
       "enter_date": "2023-04-14T00:00:00.000",
       "rough_enter_date": "Q2 2023",
-      "exit_date": "2025-08-01T00:00:00.000",
-      "rough_exit_date": "Q4 2025"
+      "exit_date": "2025-07-29T00:00:00.000",
+      "rough_exit_date": "Q3 2025"
     },
     {
       "name": "March of the Machine: The Aftermath",
@@ -304,8 +304,8 @@
       "code": "MAT",
       "enter_date": "2023-05-12T00:00:00.000",
       "rough_enter_date": "Q2 2023",
-      "exit_date": "2025-08-01T00:00:00.000",
-      "rough_exit_date": "Q4 2025"
+      "exit_date": "2025-07-29T00:00:00.000",
+      "rough_exit_date": "Q3 2025"
     },
     {
       "name": "Wilds of Eldraine",


### PR DESCRIPTION
Hi @glacials,
Buried in the MTG Arena article on rotation are the dates for paper rotation. Everything rotates out on July 29th, 2025.
https://magic.wizards.com/en/news/mtg-arena/mtg-arena-renewal-rotation

This request just updates the rotation dates listed for DMU, BRO, ONE, MOM, and MAT.