### PR TITLE
fix: EOE enter date

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -422,7 +422,7 @@
       "codename": "Volleyball",
       "block": null,
       "code": "EOE",
-      "enter_date": "2025-08-01T00:00:00.000",
+      "enter_date": "2025-07-25T00:00:00.000",
       "rough_enter_date": "Q3 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028"


### PR DESCRIPTION
As per chapter 6.3 of
https://media.wizards.com/ContentResources/WPN/MTG_MTR_2025_Apr%2021_EN.pdf:

> The following card sets are permitted in Standard tournaments
> [...]
> - Edge of Eternities (effective July 25, 2025)