### PR TITLE
fix: language for enter date

### DIFF
--- a/mobile/lib/widgets/blocks.dart
+++ b/mobile/lib/widgets/blocks.dart
@@ -38,7 +38,7 @@ class Blocks extends StatelessWidget {
                           .map((set) => PlatformListTile(
                                 leading: SetIcon(set),
                                 title: PlatformText(set.name),
-                                subtitle: set.isReleased()
+                                subtitle: set.hasEntered()
                                     ? null
                                     : PlatformText(
                                         "enters ${set.friendlyEnterDate(context)}"),

--- a/mobile/lib/widgets/blocks.dart
+++ b/mobile/lib/widgets/blocks.dart
@@ -41,7 +41,7 @@ class Blocks extends StatelessWidget {
                                 subtitle: set.isReleased()
                                     ? null
                                     : PlatformText(
-                                        "Releases ${set.friendlyEnterDate(context)}"),
+                                        "enters ${set.friendlyEnterDate(context)}"),
                               ))
                           .toList()),
                   title: "Until ${block.roughExitDate}",

--- a/mobile/lib/widgets/navigation_container.dart
+++ b/mobile/lib/widgets/navigation_container.dart
@@ -68,7 +68,7 @@ class StandardSet {
     return RelativeTime(context).format(this.exactEnterDate!);
   }
 
-  bool isReleased() {
+  bool hasEntered() {
     return this.exactEnterDate != null &&
         DateTime.now().isAfter(this.exactEnterDate!);
   }

--- a/web/src/components/SetListItem.vue
+++ b/web/src/components/SetListItem.vue
@@ -22,8 +22,8 @@ defineProps<{
     class="align-items-start border-0 border-bottom collapsed d-flex justify-content-between list-group-item p-3 set-list-item"
     :class="{
       'list-group-item-danger': set.isDropped(),
-      'list-group-item-light': set.isReleased() && !set.isDropped(),
-      'text-muted': !set.isReleased(),
+      'list-group-item-light': set.hasEntered() && !set.isDropped(),
+      'text-muted': !set.hasEntered(),
     }"
     :data-bs-target="`#accordion-collapse-${set.internalId}`"
     data-bs-toggle="collapse"
@@ -31,7 +31,7 @@ defineProps<{
   >
     <span
       :class="{
-        'text-muted': !set.isReleased(),
+        'text-muted': !set.hasEntered(),
       }"
       v-if="set.code"
     >
@@ -39,8 +39,8 @@ defineProps<{
     </span>
     <span
       :class="{
-        lead: set.isReleased(),
-        'text-muted': !set.isReleased(),
+        lead: set.hasEntered(),
+        'text-muted': !set.hasEntered(),
       }"
       v-else
     >
@@ -48,12 +48,12 @@ defineProps<{
     </span>
     <set-image
       :code="set.code || ''"
-      v-if="set.isReleased() && set.code !== undefined"
+      v-if="set.hasEntered() && set.code !== undefined"
     />
     <small
       class="font-italic"
       :title="set.enterDate.humanize()"
-      v-if="!set.isReleased()"
+      v-if="!set.hasEntered()"
       v-tippy
     >
       enters {{ set.enterDate.relative() }}

--- a/web/src/components/SetListItem.vue
+++ b/web/src/components/SetListItem.vue
@@ -56,7 +56,7 @@ defineProps<{
       v-if="!set.isReleased()"
       v-tippy
     >
-      releases {{ set.enterDate.relative() }}
+      enters {{ set.enterDate.relative() }}
     </small>
   </div>
   <div

--- a/web/src/types/card/CardSet.js
+++ b/web/src/types/card/CardSet.js
@@ -124,7 +124,7 @@ export default class CardSet {
    * Standard.
    */
   static unreleased(sets) {
-    return sets.filter((set) => !set.isReleased());
+    return sets.filter((set) => !set.hasEntered());
   }
 
   /**
@@ -142,7 +142,7 @@ export default class CardSet {
    *
    * @returns {boolean} True if the set has been released; false otherwise.
    */
-  isReleased() {
+  hasEntered() {
     return this.enterDate.hasPassed();
   }
 

--- a/web/src/types/card/Round.js
+++ b/web/src/types/card/Round.js
@@ -126,6 +126,6 @@ export default class Round {
    * @returns {boolean} - True if the round has been completely released; false otherwise.
    */
   isFullyReleased() {
-    return this.sets.every((set) => set.isReleased());
+    return this.sets.every((set) => set.hasEntered());
   }
 }


### PR DESCRIPTION
As the release date and enter date are not the same anymore since sets enter Standard on their prerelease date since last year use the word *enter* instead of *release* for sets that haven't entered Standard yet.

Rename the method used to determine if a set has entered accordingly.

See also #270.