### PR TITLE
fix: enter dates since MOM are equivalent to the prerelease date

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -312,7 +312,7 @@
       "codename": "Netball",
       "block": null,
       "code": "WOE",
-      "enter_date": "2023-09-08T00:00:00.000",
+      "enter_date": "2023-09-01T00:00:00.000",
       "rough_enter_date": "Q3 2023",
       "exit_date": null,
       "rough_exit_date": "Q1 2027"
@@ -322,7 +322,7 @@
       "codename": "Offroading",
       "block": null,
       "code": "LCI",
-      "enter_date": "2023-11-17T00:00:00.000",
+      "enter_date": "2023-11-10T00:00:00.000",
       "rough_enter_date": "Q4 2023",
       "exit_date": null,
       "rough_exit_date": "Q1 2027"
@@ -332,7 +332,7 @@
       "codename": "Polo",
       "block": null,
       "code": "MKM",
-      "enter_date": "2024-02-09T00:00:00.000",
+      "enter_date": "2024-02-02T00:00:00.000",
       "rough_enter_date": "Q1 2024",
       "exit_date": null,
       "rough_exit_date": "Q1 2027"
@@ -342,7 +342,7 @@
       "codename": "Quilting",
       "block": null,
       "code": "OTJ",
-      "enter_date": "2024-04-19T00:00:00.000",
+      "enter_date": "2024-04-12T00:00:00.000",
       "rough_enter_date": "Q2 2024",
       "exit_date": null,
       "rough_exit_date": "Q1 2027"
@@ -352,7 +352,7 @@
       "codename": "Quilting Epilogue",
       "block": null,
       "code": "BIG",
-      "enter_date": "2024-04-19T00:00:00.000",
+      "enter_date": "2024-04-12T00:00:00.000",
       "rough_enter_date": "Q2 2024",
       "exit_date": null,
       "rough_exit_date": "Q1 2027"
@@ -372,7 +372,7 @@
       "codename": "Swimming",
       "block": null,
       "code": "DSK",
-      "enter_date": "2024-09-27T00:00:00.000",
+      "enter_date": "2024-09-20T00:00:00.000",
       "rough_enter_date": "Q3 2024",
       "exit_date": null,
       "rough_exit_date": "Q1 2027"
@@ -382,7 +382,7 @@
       "codename": "Farmer",
       "block": null,
       "code": "FDN",
-      "enter_date": "2024-11-15T00:00:00.000",
+      "enter_date": "2024-11-08T00:00:00.000",
       "rough_enter_date": "Q4 2024",
       "exit_date": null,
       "rough_exit_date": "Q1 2030"
@@ -402,7 +402,7 @@
       "codename": "Ultimate",
       "block": null,
       "code": "TDM",
-      "enter_date": "2025-04-11T00:00:00.000",
+      "enter_date": "2025-04-04T00:00:00.000",
       "rough_enter_date": "Q2 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028"
@@ -412,7 +412,7 @@
       "codename": null,
       "block": null,
       "code": "FIN",
-      "enter_date": "2025-06-13T00:00:00.000",
+      "enter_date": "2025-06-06T00:00:00.000",
       "rough_enter_date": "Q2 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028"
@@ -432,7 +432,7 @@
       "codename": null,
       "block": null,
       "code": "SPM",
-      "enter_date": "2025-09-26T00:00:00.000",
+      "enter_date": "2025-09-19T00:00:00.000",
       "rough_enter_date": "Q4 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028"
@@ -442,7 +442,7 @@
       "codename": null,
       "block": null,
       "code": "TLA",
-      "enter_date": "2025-11-21T00:00:00.000",
+      "enter_date": "2025-11-14T00:00:00.000",
       "rough_enter_date": "Q4 2025",
       "exit_date": null,
       "rough_exit_date": "Q1 2028"
@@ -452,7 +452,7 @@
       "codename": "Wrestling",
       "block": null,
       "code": null,
-      "enter_date": "2026-01-23T00:00:00.000",
+      "enter_date": "2026-01-16T00:00:00.000",
       "rough_enter_date": "Q1 2026",
       "exit_date": null,
       "rough_exit_date": "Q1 2029"


### PR DESCRIPTION
Enter dates since MOM are equivalent to the prerelease date and not the release date.

Sources:
- https://magic.wizards.com/en/news/announcements/format-legality-shifts-to-prerelease-with-phyrexia-all-will-be-one
- https://magic.wizards.com/en/news/announcements/march-of-the-machine-arrives-in-2023
- https://wpn.wizards.com/en/event/prerelease-march-of-the-machine
- https://wpn.wizards.com/en/event/prerelease-the-lost-caverns-of-ixalan
- https://magic.wizards.com/en/news/announcements/on-september-8-be-ready-for-wilds-of-eldraine
- https://wpn.wizards.com/en/event/prerelease-wilds-of-eldraine
- https://wpn.wizards.com/en/event/prerelease-murders-at-karlov-manor
- https://wpn.wizards.com/en/event/prerelease-outlaws-of-thunder-junction
- https://wpn.wizards.com/en/event/prerelease-bloomburrow
- https://wpn.wizards.com/en/event/prerelease-duskmourn-house-of-horror
- https://wpn.wizards.com/en/event/prerelease-magic-the-gathering-foundations
- https://wpn.wizards.com/en/event/prerelease-aetherdrift
- https://wpn.wizards.com/en/event/prerelease-tarkir-dragonstorm
- https://wpn.wizards.com/en/event/prerelease-magic-the-gathering-final-fantasy
- https://wpn.wizards.com/en/event/prerelease-marvels-spider-man

Fixes #270