### PR TITLE
Update internal.json - Added OM1

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -438,6 +438,16 @@
       "rough_exit_date": "Q1 2028"
     },
     {
+      "name": "Through the Omenpaths",
+      "codename": null,
+      "block": null,
+      "code": "OM1",
+      "enter_date": "2025-09-23T00:00:00.000",
+      "rough_enter_date": "Q4 2025",
+      "exit_date": null,
+      "rough_exit_date": "Q1 2028"
+    },
+    {
       "name": "Avatar: The Last Airbender",
       "codename": null,
       "block": null,


### PR DESCRIPTION
Added _Through the Omenpaths_ (OM1) as a top level set.

This set is the Universes Within equivalent of Marvel's Spider-Man for _Magic Online_ (MTGO) and _Magic: The Gathering Arena_ (MTGA).