### PR TITLE
Updated enter dates - Marvel Super Heroes to Star Trek

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -492,7 +492,7 @@
       "codename": "Ziplining",
       "block": null,
       "code": null,
-      "enter_date": null,
+      "enter_date": "2026-06-26T00:00:00.000",
       "rough_enter_date": "June 2026",
       "exit_date": null,
       "rough_exit_date": "Q1 2029"
@@ -502,7 +502,7 @@
       "codename": null,
       "block": null,
       "code": null,
-      "enter_date": null,
+      "enter_date": "2026-08-14T00:00:00.000",
       "rough_enter_date": "August 2026",
       "exit_date": null,
       "rough_exit_date": "Q1 2029"
@@ -512,7 +512,7 @@
       "codename": null,
       "block": null,
       "code": null,
-      "enter_date": null,
+      "enter_date": "2026-10-02T00:00:00.000",
       "rough_enter_date": "October 2026",
       "exit_date": null,
       "rough_exit_date": "Q1 2029"
@@ -522,7 +522,7 @@
       "codename": null,
       "block": null,
       "code": null,
-      "enter_date": null,
+      "enter_date": "2026-11-20T00:00:00.000",
       "rough_enter_date": "November 2026",
       "exit_date": null,
       "rough_exit_date": "Q1 2029"


### PR DESCRIPTION
Updated the enter dates for the remaining four sets of 2026 (Marvel Super Heroes; The Hobbit; Reality Fracture; Star Trek).

Source: https://investor.hasbro.com/static-files/5836500f-a833-4850-aab5-78abca721257 (Slide 20)
<img width="2009" height="1134" alt="Screenshot 2026-03-10 121634" src="https://github.com/user-attachments/assets/51d2801e-a225-4be0-bb12-cdbb80339dd1" />
